### PR TITLE
Revised Jupyter notebooks to  explanation and make paths generic

### DIFF
--- a/analysis/organelle_removal/procedure/compare_accuracy_greengenes.ipynb
+++ b/analysis/organelle_removal/procedure/compare_accuracy_greengenes.ipynb
@@ -261,7 +261,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "working_dir = '/home/dylan/Documents/june_reset/'\n",
+    "from os.path import abspath\n",
+    "working_dir = abspath('../')\n",
     "list_of_mocks = [12,13,14,15,16,18,19,20,21,22,23]\n",
     "references = ['greengenes', 'greengenes_metaxa2']"
    ]
@@ -3016,7 +3017,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/analysis/organelle_removal/procedure/compare_annotations.ipynb
+++ b/analysis/organelle_removal/procedure/compare_annotations.ipynb
@@ -1,38 +1,44 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate a DataFrame with the percentage of Unknown and Mitochondrial reads\n",
+    "\n",
+    "For each of our compartments and references, we already have taxonomic annotations from previous steps. We now want to know what percentage of total reads were mitochondria (at level 5 of the taxonomic classification scheme), and what percentage were 'Unknown' at the most general level of within-domain classification (at level 1 of the taxonomic classification scheme).\n",
+    "\n",
+    "**Requirements**\n",
+    "It is assumed that taxonomy bar plot qzv files have been generated and are stored in the top level of the ../output/ directory. It is further assumed that each is named based on *compartment*_*reference*_tbp.qzv so for example M_greengenes_tbp.qzv would indicate the set of mucus samples annotated according to Greengenes 13_8.\n",
+    "\n",
+    "**Output**\n",
+    "Two .csv files will be output, with columns summarizing the percentage of mitochondria and Unknown bacteria according to each annotation scheme and compartment\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#data wrangling. now that we have the numbers, it's just a matter of\n",
-    "#combining them into a useful output"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import tempfile\n",
     "from qiime2 import Visualization\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "import os"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "working_dir = '/home/dylan/Documents/june_reset'"
+    "working_dir = os.path.abspath('../')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,8 +86,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Export results to lvl1.csv and lvl5.csv files"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,11 +115,275 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "#### Show the final results as HTML"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Proportion Unassigned\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>proportion unassigned</th>\n",
+       "      <th>reference taxonomy</th>\n",
+       "      <th>tissue compartment</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.228988</td>\n",
+       "      <td>greengenes</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.558824</td>\n",
+       "      <td>greengenes</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.931076</td>\n",
+       "      <td>greengenes</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.021456</td>\n",
+       "      <td>greengenes</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.082127</td>\n",
+       "      <td>greengenes</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5083</th>\n",
+       "      <td>0.001788</td>\n",
+       "      <td>silva_metaxa2</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5084</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>silva_metaxa2</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5085</th>\n",
+       "      <td>0.000826</td>\n",
+       "      <td>silva_metaxa2</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5086</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>silva_metaxa2</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5087</th>\n",
+       "      <td>0.001944</td>\n",
+       "      <td>silva_metaxa2</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5088 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      proportion unassigned reference taxonomy tissue compartment\n",
+       "0                  0.228988         greengenes                  M\n",
+       "1                  0.558824         greengenes                  M\n",
+       "2                  0.931076         greengenes                  M\n",
+       "3                  0.021456         greengenes                  M\n",
+       "4                  0.082127         greengenes                  M\n",
+       "...                     ...                ...                ...\n",
+       "5083               0.001788      silva_metaxa2                  S\n",
+       "5084               0.000000      silva_metaxa2                  S\n",
+       "5085               0.000826      silva_metaxa2                  S\n",
+       "5086               0.000000      silva_metaxa2                  S\n",
+       "5087               0.001944      silva_metaxa2                  S\n",
+       "\n",
+       "[5088 rows x 3 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Proportion Mitochondria\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>proportion mitochondria</th>\n",
+       "      <th>reference taxonomy</th>\n",
+       "      <th>tissue compartment</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>greengenes</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>greengenes</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.000038</td>\n",
+       "      <td>greengenes</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>greengenes</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>greengenes</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5083</th>\n",
+       "      <td>0.025550</td>\n",
+       "      <td>silva_metaxa2</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5084</th>\n",
+       "      <td>0.363636</td>\n",
+       "      <td>silva_metaxa2</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5085</th>\n",
+       "      <td>0.002811</td>\n",
+       "      <td>silva_metaxa2</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5086</th>\n",
+       "      <td>0.029424</td>\n",
+       "      <td>silva_metaxa2</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5087</th>\n",
+       "      <td>0.816483</td>\n",
+       "      <td>silva_metaxa2</td>\n",
+       "      <td>S</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5088 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      proportion mitochondria reference taxonomy tissue compartment\n",
+       "0                    0.000000         greengenes                  M\n",
+       "1                    0.000000         greengenes                  M\n",
+       "2                    0.000038         greengenes                  M\n",
+       "3                    0.000000         greengenes                  M\n",
+       "4                    0.000000         greengenes                  M\n",
+       "...                       ...                ...                ...\n",
+       "5083                 0.025550      silva_metaxa2                  S\n",
+       "5084                 0.363636      silva_metaxa2                  S\n",
+       "5085                 0.002811      silva_metaxa2                  S\n",
+       "5086                 0.029424      silva_metaxa2                  S\n",
+       "5087                 0.816483      silva_metaxa2                  S\n",
+       "\n",
+       "[5088 rows x 3 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.core.display import display\n",
+    "print(\"Proportion Unassigned\")\n",
+    "display(lvl1_df)\n",
+    "print(\"Proportion Mitochondria\")\n",
+    "display(lvl5_df)"
+   ]
   }
  ],
  "metadata": {
@@ -125,7 +402,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/analysis/organelle_removal/procedure/compartment_split.ipynb
+++ b/analysis/organelle_removal/procedure/compartment_split.ipynb
@@ -1,29 +1,29 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "#import the GCMP biom table and split it into 3 feature tables, one for\n",
-    "#each compartment"
+    "## Create Filtered Feature Tables\n",
+    "\n",
+    "Split the GCMP feature table into 3 feature tables, one each for mucus, tissue, and skeletal samples\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
     "from qiime2 import Artifact\n",
     "from qiime2.plugins.feature_table.methods import filter_samples\n",
-    "from qiime2.metadata import Metadata"
+    "from qiime2.metadata import Metadata\n",
+    "from os.path import abspath,exists"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,41 +34,99 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 4,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "working_dir = '/home/dylan/Documents/june_reset'"
+    "As in past notebooks, we assume the analysis is structured in directories as follows:\n",
+    "<pre>\n",
+    "\n",
+    "analysis_name/\n",
+    "   input/\n",
+    "       input_files (.biom, etc)\n",
+    "   output/\n",
+    "   procedure/\n",
+    "       this_notebook.ipynb\n",
+    "</pre>\n",
+    "\n",
+    "#### Set up variables to hold paths for all input files"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "working_dir = abspath('../')\n",
+    "biom_path = working_dir + '/input/all.biom'\n",
+    "metadata_path = working_dir + '/input/GCMP_EMP_map_r28_no_empty_samples.txt'\n",
+    "seqs_path = working_dir + '/input/all.seqs.fa'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Verify that input files exist at the above paths\n",
+    "\n",
+    "Let's run a quick check to make sure we have everything we need:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verifying that all needed starting data files exist.\n",
+      "Done.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Verifying that all needed starting data files exist.\")\n",
+    "for existing_file in [biom_path,metadata_path,seqs_path]:\n",
+    "    if not exists(existing_file):\n",
+    "        raise IOError(f\"Required file {existing_file} not found. Please ensure it is in that directory.\")\n",
+    "print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Import the GCMP feature table and metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
     "#import the biom table as a feature table\n",
-    "biom_path = working_dir + '/input/all.biom'\n",
     "GCMP_ft = Artifact.import_data('FeatureTable[Frequency]', biom_path,\n",
     "                               'BIOMV210Format')\n",
-    "#import_data(type, view, view_type=None)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "\n",
     "#import the metadata\n",
-    "metadata_path = working_dir + '/input/GCMP_EMP_map_r28_no_empty_samples.txt'\n",
     "metadata = Metadata.load(metadata_path)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Split the GCMP feature table by compartment\n",
+    "\n",
+    "The GCMP includes samples from coral mucus, tissue, and skeleton, as well as some contextual water and sediment samples. Here we create separate .qza feature tables by filtering for just mucus, tissue or skeleton samples."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,22 +136,28 @@
     "    where = \"tissue_compartment='\" + compartment + \"'\"\n",
     "    GCMP_filtered, = filter_samples(GCMP_ft, metadata = metadata,\n",
     "                                   where = where)\n",
-    "    save_path = working_dir + '/input/' + compartment + \"_ft.qza\"\n",
+    "    save_path = working_dir + '/output/' + compartment + \"_ft.qza\"\n",
     "    GCMP_filtered.save(save_path)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Load the GCMP Sequences\n",
+    "\n",
+    "QIIME2 requires sequences to be in uppercase. However the GCMP fasta file has a mix of upper and lowercase sequences. Therefore we have to manually convert sequences (but not sequence labels) to uppercase prior to loading into QIIME2. "
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#import the sequences\n",
-    "#mix of upper and lowercase; this version of qiime is not a fan\n",
-    "seqs_path = working_dir + '/input/all.seqs.fa'\n",
-    "upper_seqs_path = working_dir + '/input/GCMP.fasta'\n",
+    "upper_seqs_path = working_dir + '/output/GCMP.fasta'\n",
     "with open(seqs_path) as infile:\n",
-    "    with open(upper_seqs_path, \"a\") as outfile:\n",
+    "    with open(upper_seqs_path, \"w\") as outfile:\n",
     "        for line in infile:\n",
     "            #careful to preserve the headers so they match the feature table\n",
     "            if not line.startswith(\">\"):\n",
@@ -102,17 +166,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have made a file of uppercase sequences we should be abble to import into QIIME2 and save a .qza artifact"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'/home/dylan/Documents/june_reset/input/GCMP_seqs.qza'"
+       "'/Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/output/GCMP_seqs.qza'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -120,15 +191,8 @@
    "source": [
     "#now we can import, and save the artifact\n",
     "GCMP_seqs = Artifact.import_data('FeatureData[Sequence]', upper_seqs_path)\n",
-    "GCMP_seqs.save(working_dir + '/input/GCMP_seqs.qza')"
+    "GCMP_seqs.save(working_dir + '/output/GCMP_seqs.qza')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -147,7 +211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/analysis/organelle_removal/procedure/create_barplots.ipynb
+++ b/analysis/organelle_removal/procedure/create_barplots.ipynb
@@ -1,39 +1,48 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "#using the classification taxonomies, create taxa bar plots for each\n",
-    "#tissue compartment"
+    "## Annotate Taxonomy and Create Taxonomy Barplots\n",
+    "\n",
+    "Using the classification taxonomies, create taxa bar plots for each tissue compartment.\n",
+    "\n",
+    "**Requirements**\n",
+    "\n",
+    "This notebook assumes we have a metadata file in ../input/ and taxonomy annotation .qza files according to each reference saved in the top level of ../output/\n",
+    "\n",
+    "**Output**\n",
+    "\n",
+    "Taxonomy bar plots for each compartment (mucus, tissue and skeleton) will be saved to the output folder"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "from qiime2 import Artifact\n",
     "from qiime2.metadata import Metadata\n",
     "from qiime2.plugins.taxa.visualizers import barplot\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "import os"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "working_dir = '/home/dylan/Documents/june_reset'"
+    "working_dir = os.path.abspath('../')\n",
+    "metadata_path = working_dir + '/input/GCMP_EMP_map_r28_no_empty_samples.txt'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,95 +51,22 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>#SampleID</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>10895.BLANK.1.5A</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10895.BLANK.10.A7</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10895.BLANK.10.A8</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10895.BLANK.10.B7</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10895.BLANK.10.B8</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10895.E9.Out.Sti.giga.1.20150823.M</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10895.E9.Sediment.1.20150817</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10895.E9.Sediment.1.20150818</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10895.E9.Sediment.1.20150823</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10895.unknown.1</th>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>1438 rows × 0 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: []\n",
-       "Index: [10895.BLANK.1.5A, 10895.BLANK.10.A7, 10895.BLANK.10.A8, 10895.BLANK.10.B7, 10895.BLANK.10.B8, 10895.BLANK.10.C7, 10895.BLANK.10.C8, 10895.BLANK.10.D7, 10895.BLANK.10.D8, 10895.BLANK.10.E7, 10895.BLANK.10.E8, 10895.BLANK.10.F10, 10895.BLANK.10.F7, 10895.BLANK.10.F8, 10895.BLANK.10.G10, 10895.BLANK.10.G7, 10895.BLANK.10.G8, 10895.BLANK.10.H10, 10895.BLANK.10.H7, 10895.BLANK.10.H8, 10895.BLANK.11.E8, 10895.BLANK.11.F8, 10895.BLANK.11.G8, 10895.BLANK.11.H8, 10895.BLANK.12.G6, 10895.BLANK.12.H6, 10895.BLANK.13.C9, 10895.BLANK.13.D9, 10895.BLANK.13.E9, 10895.BLANK.13.F9, 10895.BLANK.13.G9, 10895.BLANK.13.H9, 10895.BLANK.14.A8, 10895.BLANK.14.B8, 10895.BLANK.14.C8, 10895.BLANK.14.D8, 10895.BLANK.14.E8, 10895.BLANK.14.F8, 10895.BLANK.14.G8, 10895.BLANK.15.A12, 10895.BLANK.15.A5, 10895.BLANK.15.B12, 10895.BLANK.15.B5, 10895.BLANK.15.C12, 10895.BLANK.15.C5, 10895.BLANK.15.D12, 10895.BLANK.15.D5, 10895.BLANK.15.E12, 10895.BLANK.15.E5, 10895.BLANK.15.F5, 10895.BLANK.2.11, 10895.BLANK.2.11D, 10895.BLANK.2.11E, 10895.BLANK.2.11F, 10895.BLANK.2.11G, 10895.BLANK.2.1H, 10895.BLANK.3.10E, 10895.BLANK.3.10F, 10895.BLANK.3.10G, 10895.BLANK.3.10H, 10895.BLANK.4.6E, 10895.BLANK.4.6F, 10895.BLANK.4.6G, 10895.BLANK.4.6H, 10895.BLANK.5.4F, 10895.BLANK.5.4G, 10895.BLANK.5.4H, 10895.BLANK.6.2B, 10895.BLANK.6.2C, 10895.BLANK.6.2D, 10895.BLANK.6.2E, 10895.BLANK.6.2F, 10895.BLANK.6.2G, 10895.BLANK.6.2H, 10895.BLANK.6.4D, 10895.BLANK.6.4E, 10895.BLANK.6.4F, 10895.BLANK.6.4G, 10895.BLANK.6.4H, 10895.BLANK.6.G9, 10895.BLANK.7.A12, 10895.BLANK.7.B12, 10895.BLANK.7.C12, 10895.BLANK.7.D12, 10895.BLANK.7.E12, 10895.BLANK.7.F12, 10895.BLANK.7.G12, 10895.BLANK.7.H12, 10895.BLANK.7.H4, 10895.BLANK.8.A11, 10895.BLANK.8.B11, 10895.BLANK.8.C11, 10895.BLANK.8.D11, 10895.BLANK.8.E11, 10895.BLANK.8.F11, 10895.BLANK.8.G11, 10895.BLANK.8.H11, 10895.BLANK.9.D10, 10895.BLANK.9.E10, 10895.BLANK.9.F10, ...]\n",
-       "\n",
-       "[1438 rows x 0 columns]"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "#we don't actually care about the information in the metadata, so we\n",
-    "#strip everything but the index. Otherwise the metadata gets appended\n",
-    "#to the csvs\n",
-    "metadata_path = working_dir + '/input/GCMP_EMP_map_r28_no_empty_samples.txt'\n",
+    "#### Simplify output data for analysis in python.\n",
+    "\n",
+    "We don't actually care about the information in the metadata, so we\n",
+    "strip everything but the index. Otherwise the metadata gets appended\n",
+    "to the csvs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "metadata = Metadata.load(metadata_path)\n",
     "metadata_df = metadata.to_dataframe()\n",
     "metadata_df = pd.DataFrame(index=metadata_df.index)\n",
@@ -138,8 +74,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Make taxonomy barplots for each taxonomic scheme and compartment"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,19 +90,12 @@
     "    taxonomy_path = working_dir + '/output/' + reference + '_reference_taxonomy.qza'\n",
     "    taxonomy = Artifact.load(taxonomy_path)\n",
     "    for compartment in compartments:\n",
-    "        ft_path = working_dir + '/input/' + compartment + '_ft.qza'\n",
+    "        ft_path = working_dir + '/output/' + compartment + '_ft.qza'\n",
     "        ft = Artifact.load(ft_path)\n",
     "        tbp, = barplot(ft, taxonomy, metadata)\n",
     "        save_path = working_dir + '/output/' + compartment + '_' + reference + '_tbp.qzv'\n",
     "        tbp.save(save_path)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -178,7 +114,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/analysis/organelle_removal/procedure/create_taxonomy_artifacts.ipynb
+++ b/analysis/organelle_removal/procedure/create_taxonomy_artifacts.ipynb
@@ -1,234 +1,362 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create QIIME2 Taxonomy Artifact Files\n",
+    "\n",
+    "For QIIME2 to annotate taxonomy, it requires that we create taxonomy .qza files. In this notebook, we will create such taxonomy files by supplementing the Greengenes and SILVA databases with additional mitochondrial 12S rRNA gene sequences from the MeTaxa2 project\n",
+    "\n",
+    "The script assumes the following files are already together in a folder. (By default this is ../outputs/taxonomy_references/):\n",
+    "\n",
+    "gg_13_8_otus/ (derived from gg_13_8_otus.tar.gz, downloaded from ftp://greengenes.microbio.me/greengenes_release/gg_13_5/gg_13_8_otus.tar.gz)\n",
+    "Silva_132_release/ (derived from Silva_132_release.zip downloaded from https://www.arb-silva.de/fileadmin/silva_databases/qiime/Silva_132_release.zip)\n",
+    "metaxa2.fasta (constructed from the MeTaxa2 BLAST database, https://microbiology.se/sw/Metaxa2_2.2.1.tar.gz)\n",
+    "\n",
+    "These are all manually downloaded and extracted by the download_starting_taxonomy_files.ipynb notebook \n",
+    "\n",
+    "The script further requires the following libraries:\n",
+    "\n",
+    "-- The QIIME2 software and dependencies (we ran it from within the qiime2-2020.6 conda environment) \n",
+    "-- Biopython installed within the QIIME2 conda environment (I used conda install biopython)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Import python libraries\n",
+    "\n",
+    "Note that this step will fail if Biopython or QIIME2 are not installed..."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [],
    "source": [
     "from Bio import SeqIO\n",
-    "from qiime2 import Artifact"
+    "from qiime2 import Artifact\n",
+    "import os"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "#manually downloaded:\n",
-    "#all.seqs.fa\n",
-    "#all.biom\n",
-    "#GCMP_EMP_map_r28_no_empty_samples.txt\n",
-    "#gg_13_8_otus.tar.gz (from ftp://greengenes.microbio.me/greengenes_release/gg_13_5/gg_13_8_otus.tar.gz)\n",
-    "#Silva_132_release.zip (from https://www.arb-silva.de/fileadmin/silva_databases/qiime/Silva_132_release.zip)\n",
+    "#### Define paths for new and existing files \n",
     "\n",
-    "#manually extract silva and greengenes"
+    "All paths are defined here to make the below code more modular.\n",
+    "\n",
+    "Basically for each resource (Greengenes or SILVA) we need a FASA file with the actual sequences, and a taxonomy file that says how those sequences map into taxonomic categories. From these, we generate a new sequence and taxonomy file that has the original info plus the new sequences from MeTaxa2."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#extract mitochondria sequences from Metaxa2 and create a separate taxonomy file in the style of greengenes\n",
-    "working_dir = '/home/dylan/Documents/june_reset'\n",
-    "metaxa_path = working_dir + '/input/metaxa2.fasta'\n",
-    "greengenes_path = working_dir + '/input/gg_13_8_otus/rep_set/99_otus.fasta'\n",
-    "with open((working_dir + '/input/m2+gg_otus.fasta'), \"a\") as otu_file:\n",
-    "    with open((working_dir + '/input/m2+gg_taxonomy.txt'), \"a\") as taxonomy_file:\n",
-    "        for i, entry in enumerate(SeqIO.parse(metaxa_path, \"fasta\")):\n",
-    "            if 'mitochondria' in entry.description or 'Mitochondria' in entry.description:\n",
-    "                otu_file.write(\">metaxa2_\" + str(i) + \"\\n\")\n",
-    "                otu_file.write(str(entry.seq + \"\\n\"))\n",
-    "                taxonomy_file.write(\"metaxa2_\" + str(i) + \"\\tk__Bacteria; p__Proteobacteria; c__Alphaproteobacteria; o__Rickettsiales; f__mitochondria; g__; s__\\n\")\n",
-    "            else:\n",
-    "                continue"
+    "## Set up input and output directories\n",
+    "working_dir = os.path.abspath('../output/taxonomy_references/')\n",
+    "\n",
+    "#Set up variables for relevant files\n",
+    "#Note in variable names we follow the convention m2 = MeTaxa2, gg = greengenes\n",
+    "\n",
+    "#Existing files:\n",
+    "gg_fasta_path = working_dir + '/gg_13_8_otus/rep_set/99_otus.fasta'\n",
+    "gg_taxonomy_path = working_dir+'/gg_13_8_otus/taxonomy/99_otu_taxonomy.txt'\n",
+    "\n",
+    "silva_fasta_path = working_dir + '/SILVA_132_QIIME_release/rep_set/rep_set_16S_only/99/silva_132_99_16S.fna'\n",
+    "silva_taxonomy_path = working_dir + '/SILVA_132_QIIME_release/taxonomy/16S_only/99/taxonomy_7_levels.txt'\n",
+    "m2_fasta_path = working_dir + '/metaxa2.fasta'\n",
+    "\n",
+    "\n",
+    "#New intermediate/raw data files:\n",
+    "gg_plus_m2_fasta_path = working_dir + '/m2+gg_otus.fasta'\n",
+    "gg_plus_m2_taxonomy_path = working_dir + '/m2+gg_taxonomy.txt'\n",
+    "silva_plus_m2_fasta_path = working_dir + '/m2+silva_otus.fasta'\n",
+    "silva_plus_m2_taxonomy_path = working_dir + '/m2+silva_taxonomy.txt'\n",
+    "\n",
+    "#New QIIME2 .qza artifact files:\n",
+    "gg_otus_qza = working_dir + '/greengenes_otus.qza'\n",
+    "gg_taxonomy_qza = working_dir + '/greengenes_taxonomy.qza'\n",
+    "gg_m2_otus_qza = working_dir + '/greengenes_metaxa2_otus.qza'\n",
+    "gg_m2_taxonomy_qza = working_dir + '/greengenes_metaxa2_taxonomy.qza'\n",
+    "silva_otus_qza = working_dir + '/silva_otus.qza'\n",
+    "silva_taxonomy_qza = working_dir + '/silva_taxonomy.qza'\n",
+    "silva_m2_otus_qza = working_dir + '/silva_metaxa2_otus.qza'\n",
+    "silva_m2_taxonomy_qza = working_dir + '/silva_metaxa2_taxonomy.qza'"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 12,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "#copy greengenes otus into the combined file\n",
-    "with open((working_dir + '/input/m2+gg_otus.fasta'), \"a\") as otu_file:\n",
-    "    for entry in SeqIO.parse(greengenes_path, \"fasta\"):\n",
-    "        otu_file.write(\">\" + str(entry.description) + \"\\n\")\n",
-    "        otu_file.write(str(entry.seq) + \"\\n\")"
+    "#### Verify that all input files exist\n",
+    "\n",
+    "Let's run a quick check to make sure all input files actually exist"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#copy greengenes taxonomy into the combined file\n",
-    "with open((working_dir + '/input/m2+gg_taxonomy.txt'), \"a\") as taxonomy_file:\n",
-    "    with open(working_dir + '/input/gg_13_8_otus/taxonomy/99_otu_taxonomy.txt') as greengenes_taxonomy_file:\n",
-    "        for line in greengenes_taxonomy_file:\n",
-    "            taxonomy_file.write(line)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#extract mitochondria sequences from Metaxa2 and create a separate taxonomy file in the style of SILVA\n",
-    "silva_path = working_dir + '/input/Silva_132_release/SILVA_132_QIIME_release/rep_set/rep_set_16S_only/99/silva_132_99_16S.fna'\n",
-    "with open((working_dir + '/input/m2+silva_otus.fasta'), \"a\") as otu_file:\n",
-    "    with open((working_dir + '/input/m2+silva_taxonomy.txt'), \"a\") as taxonomy_file:\n",
-    "        for i, entry in enumerate(SeqIO.parse(metaxa_path, \"fasta\")):\n",
-    "            if 'mitochondria' in entry.description or 'Mitochondria' in entry.description:\n",
-    "                otu_file.write(\">metaxa2_\" + str(i) + \"\\n\")\n",
-    "                otu_file.write(str(entry.seq + \"\\n\"))\n",
-    "                taxonomy_file.write(\"metaxa2_\" + str(i) + \"\\tD_0__Bacteria;D_1__Proteobacteria;D_2__Alphaproteobacteria;D_3__Rickettsiales;D_4__Mitochondria;D_5__uncultured bacterium;D_6__uncultured bacterium\\n\")\n",
-    "            else:\n",
-    "                continue"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#copy silva otus into the combined file\n",
-    "with open((working_dir + '/input/m2+silva_otus.fasta'), \"a\") as otu_file:\n",
-    "    for entry in SeqIO.parse(silva_path, \"fasta\"):\n",
-    "        otu_file.write(\">\" + str(entry.description) + \"\\n\")\n",
-    "        otu_file.write(str(entry.seq) + \"\\n\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#copy silva taxonomy into the combined file\n",
-    "with open((working_dir + '/input/m2+silva_taxonomy.txt'), \"a\") as taxonomy_file:\n",
-    "    with open(working_dir + '/input/Silva_132_release/SILVA_132_QIIME_release/taxonomy/16S_only/99/taxonomy_7_levels.txt') as silva_taxonomy_file:\n",
-    "        for line in silva_taxonomy_file:\n",
-    "            taxonomy_file.write(line)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "<artifact: FeatureData[Taxonomy] uuid: 57e63fc0-5bbd-4dc0-814d-5c497b803252>"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verifying that all needed starting data files exist.\n",
+      "Done.\n"
+     ]
     }
    ],
    "source": [
+    "print(\"Verifying that all needed starting data files exist.\")\n",
+    "for existing_file in [gg_fasta_path,gg_taxonomy_path,silva_fasta_path,silva_taxonomy_path,m2_fasta_path]:\n",
+    "    if not os.path.exists(existing_file):\n",
+    "        raise IOError(f\"Required file {existing_file} not found. Please ensure it is in that directory.\")\n",
+    "print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create a combined Greengenes plus MeTaxa2 fasta and taxonomy file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#extract mitochondria sequences from Metaxa2 and add them to new\n",
+    "#fasta and taxonomy files in the style of greengenes\n",
+    "\n",
+    "otu_file = open(gg_plus_m2_fasta_path, \"a\")\n",
+    "taxonomy_file = open(gg_plus_m2_taxonomy_path, \"a\") \n",
+    "\n",
+    "#Add MeTaxa2 data to the gg_plus_m2 fasta and taxonomy files\n",
+    "for i, entry in enumerate(SeqIO.parse(metaxa_path, \"fasta\")):\n",
+    "    if 'mitochondria' in entry.description or 'Mitochondria' in entry.description:\n",
+    "        otu_file.write(\">metaxa2_\" + str(i) + \"\\n\")\n",
+    "        otu_file.write(str(entry.seq + \"\\n\"))\n",
+    "        taxonomy_file.write(\"metaxa2_\" + str(i) + \"\\tk__Bacteria; p__Proteobacteria; c__Alphaproteobacteria; o__Rickettsiales; f__mitochondria; g__; s__\\n\")\n",
+    "    else:\n",
+    "        continue\n",
+    "        \n",
+    "#copy greengenes otus into the gg_plus_m2 fasta file        \n",
+    "for entry in SeqIO.parse(gg_fasta_path, \"fasta\"):\n",
+    "        otu_file.write(\">\" + str(entry.description) + \"\\n\")\n",
+    "        otu_file.write(str(entry.seq) + \"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#copy greengenes taxonomy into the combined taxonomy file\n",
+    "greengenes_taxonomy_file = open(gg_taxonomy_path) \n",
+    "for line in greengenes_taxonomy_file:\n",
+    "    taxonomy_file.write(line)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verifying that all gg_plus_m2 data files were created.\n",
+      "Successfully created file: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/output/taxonomy_references/m2+gg_otus.fasta\n",
+      "Successfully created file: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/output/taxonomy_references/m2+gg_taxonomy.txt\n",
+      "Done.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Verify that we really created all files we were supposed to\n",
+    "\n",
+    "print(\"Verifying that all gg_plus_m2 data files were created.\")\n",
+    "for created_file in [gg_plus_m2_fasta_path,gg_plus_m2_taxonomy_path]:\n",
+    "    if not os.path.exists(created_file):\n",
+    "        raise IOError(f\"Required file {created_file} not found. Please ensure it is in that directory.\")\n",
+    "    print(\"Successfully created file:\",created_file)\n",
+    "    \n",
+    "print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Supplement the SILVA database with MeTaxa2 sequences\n",
+    "\n",
+    "We'll now repeat the process to supplement the SILVA database with MeTaxa2 mitochondrial sequences"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#extract mitochondria sequences from Metaxa2 and create separate fasta and taxonomy files in the style of SILVA\n",
+    "otu_file = open(silva_plus_m2_fasta_path, \"a\") \n",
+    "taxonomy_file = open(silva_plus_m2_taxonomy_path, \"a\")\n",
+    "\n",
+    "for i, entry in enumerate(SeqIO.parse(metaxa_path, \"fasta\")):\n",
+    "    if 'mitochondria' in entry.description or 'Mitochondria' in entry.description:\n",
+    "        otu_file.write(\">metaxa2_\" + str(i) + \"\\n\")\n",
+    "        otu_file.write(str(entry.seq + \"\\n\"))\n",
+    "        taxonomy_file.write(\"metaxa2_\" + str(i) + \"\\tD_0__Bacteria;D_1__Proteobacteria;D_2__Alphaproteobacteria;D_3__Rickettsiales;D_4__Mitochondria;D_5__uncultured bacterium;D_6__uncultured bacterium\\n\")\n",
+    "    else:\n",
+    "        continue"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#copy silva otus into the combined fasta file \n",
+    "for entry in SeqIO.parse(silva_fasta_path, \"fasta\"):\n",
+    "    otu_file.write(\">\" + str(entry.description) + \"\\n\")\n",
+    "    otu_file.write(str(entry.seq) + \"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#copy silva taxonomy into the combined taxonomy file\n",
+    "silva_taxonomy_file = open(silva_taxonomy_path) \n",
+    "for line in silva_taxonomy_file:\n",
+    "    taxonomy_file.write(line)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verifying that all silva_plus_m2 data files were created.\n",
+      "Successfully created file: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/output/taxonomy_references/m2+silva_otus.fasta\n",
+      "Successfully created file: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/output/taxonomy_references/m2+silva_taxonomy.txt\n",
+      "Done.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Verify that we really created all files we were supposed to\n",
+    "\n",
+    "print(\"Verifying that all silva_plus_m2 data files were created.\")\n",
+    "for created_file in [silva_plus_m2_fasta_path,silva_plus_m2_taxonomy_path]:\n",
+    "    if not os.path.exists(created_file):\n",
+    "        raise IOError(f\"Required file {created_file} not found. Please ensure it is in that directory.\")\n",
+    "    print(\"Successfully created file:\",created_file)\n",
+    "    \n",
+    "print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import the Greengenes + Metaxa2 data into QIIME2 and export taxonomy .qzas\n",
+    "\n",
+    "We now should have all the info we need to generate new QIIME2 taxonomy .qza files that can be used for taxonomic annotation. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#create greengenes taxonomy and OTU artifacts\n",
-    "gg_otu_path = working_dir + '/input/gg_13_8_otus/rep_set/99_otus.fasta'\n",
-    "gg_taxonomy_path = working_dir + '/input/gg_13_8_otus/taxonomy/99_otu_taxonomy.txt'\n",
-    "gg_otus = Artifact.import_data('FeatureData[Sequence]', gg_otu_path)\n",
+    "gg_otus = Artifact.import_data('FeatureData[Sequence]', gg_fasta_path)\n",
     "gg_taxonomy = Artifact.import_data('FeatureData[Taxonomy]', gg_taxonomy_path, 'HeaderlessTSVTaxonomyFormat')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 113,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<artifact: FeatureData[Taxonomy] uuid: 04ec4b1a-47a1-44db-99d4-8d1dea7b4657>"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#create greengenes+m2 taxonomy and otu artifacts\n",
-    "gg_m2_otu_path = working_dir + '/input/m2+gg_otus.fasta'\n",
-    "gg_m2_taxonomy_path = working_dir + '/input/m2+gg_taxonomy.txt'\n",
-    "gg_m2_otus = Artifact.import_data('FeatureData[Sequence]', gg_m2_otu_path)\n",
-    "gg_m2_taxonomy = Artifact.import_data('FeatureData[Taxonomy]', gg_m2_taxonomy_path, 'HeaderlessTSVTaxonomyFormat')"
+    "gg_m2_otus = Artifact.import_data('FeatureData[Sequence]', gg_plus_m2_fasta_path)\n",
+    "gg_m2_taxonomy = Artifact.import_data('FeatureData[Taxonomy]', \n",
+    "  gg_plus_m2_taxonomy_path, 'HeaderlessTSVTaxonomyFormat')\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 114,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<artifact: FeatureData[Taxonomy] uuid: 1f3b97c4-b63a-4b85-b456-736ef2228f33>"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#create SILVA taxonomy and OTU artifacts\n",
-    "silva_otu_path = working_dir + '/input/Silva_132_release/SILVA_132_QIIME_release/rep_set/rep_set_16S_only/99/silva_132_99_16S.fna'\n",
-    "silva_taxonomy_path = working_dir + '/input/Silva_132_release/SILVA_132_QIIME_release/taxonomy/16S_only/99/taxonomy_7_levels.txt'\n",
-    "silva_otus = Artifact.import_data('FeatureData[Sequence]', silva_otu_path)\n",
+    "silva_otus = Artifact.import_data('FeatureData[Sequence]', silva_fasta_path)\n",
     "silva_taxonomy = Artifact.import_data('FeatureData[Taxonomy]', silva_taxonomy_path, 'HeaderlessTSVTaxonomyFormat')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#create greengenes+m2 taxonomy and otu artifacts\n",
-    "silva_m2_otu_path = working_dir + '/input/m2+silva_otus.fasta'\n",
-    "silva_m2_taxonomy_path = working_dir + '/input/m2+silva_taxonomy.txt'\n",
-    "silva_m2_otus = Artifact.import_data('FeatureData[Sequence]', silva_m2_otu_path)\n",
-    "silva_m2_taxonomy = Artifact.import_data('FeatureData[Taxonomy]', silva_m2_taxonomy_path, 'HeaderlessTSVTaxonomyFormat')"
+    "#create SILVA+m2 taxonomy and otu artifacts\n",
+    "silva_m2_otus = Artifact.import_data('FeatureData[Sequence]', silva_plus_m2_fasta_path)\n",
+    "silva_m2_taxonomy = Artifact.import_data('FeatureData[Taxonomy]', silva_plus_m2_taxonomy_path, 'HeaderlessTSVTaxonomyFormat')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'/home/dylan/Documents/june_reset/input/silva_m2_taxonomy.qza'"
+       "'/Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/output/taxonomy_references/silva_metaxa2_taxonomy.qza'"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "#export the artifacts to the input folder\n",
-    "gg_otus.save(working_dir + '/input/greengenes_otus.qza')\n",
-    "gg_taxonomy.save(working_dir + '/input/greengenes_taxonomy.qza')\n",
-    "gg_m2_otus.save(working_dir + '/input/greengenes_metaxa2_otus.qza')\n",
-    "gg_m2_taxonomy.save(working_dir + '/input/greengenes_metaxa2_taxonomy.qza')\n",
-    "silva_otus.save(working_dir + '/input/silva_otus.qza')\n",
-    "silva_taxonomy.save(working_dir + '/input/silva_taxonomy.qza')\n",
-    "silva_m2_otus.save(working_dir + '/input/silva_metaxa2_otus.qza')\n",
-    "silva_m2_taxonomy.save(working_dir + '/input/silva_metaxa2_taxonomy.qza')"
+    "#export the artifacts to the output folder\n",
+    "gg_otus.save(gg_otus_qza)\n",
+    "gg_taxonomy.save(gg_taxonomy_qza)\n",
+    "gg_m2_otus.save(gg_m2_otus_qza)\n",
+    "gg_m2_taxonomy.save(gg_m2_taxonomy_qza)\n",
+    "silva_otus.save(silva_otus_qza)\n",
+    "silva_taxonomy.save(silva_taxonomy_qza)\n",
+    "silva_m2_otus.save(silva_m2_otus_qza)\n",
+    "silva_m2_taxonomy.save(silva_m2_taxonomy_qza)"
    ]
   },
   {
@@ -255,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/analysis/organelle_removal/procedure/download_starting_taxonomy_files.ipynb
+++ b/analysis/organelle_removal/procedure/download_starting_taxonomy_files.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -147,7 +147,7 @@
      "output_type": "stream",
      "text": [
       "Downloading file: ftp://greengenes.microbio.me/greengenes_release/gg_13_5/gg_13_8_otus.tar.gz\n",
-      "Saved to local filepath: ../output/taxonomy_references/gg_13_8_otus.tar.gz\n"
+      "Saved to local filepath: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/output/taxonomy_references/gg_13_8_otus.tar.gz\n"
      ]
     }
    ],
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -195,7 +195,7 @@
      "output_type": "stream",
      "text": [
       "Downloading file:  https://www.arb-silva.de/fileadmin/silva_databases/qiime/Silva_132_release.zip\n",
-      "Saved to local filepath: ../output/taxonomy_references/Silva_132_release.zip\n"
+      "Saved to local filepath: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/output/taxonomy_references/Silva_132_release.zip\n"
      ]
     }
    ],
@@ -205,9 +205,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting SILVA database...\n",
+      "Extracted the SILVA 132 database into: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/output/taxonomy_references\n"
+     ]
+    }
+   ],
    "source": [
     "from zipfile import is_zipfile, ZipFile\n",
     "\n",
@@ -235,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -260,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -294,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -307,7 +316,7 @@
       "Resulting FASTA file(s):\n",
       "./metaxa2.fasta\n",
       "Moved metaxa2.fasta to /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/output/taxonomy_references/metaxa2.fasta\n",
-      "Changed working directory back to  /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/procedure\n"
+      "Changed working directory back to:  /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/GCMP_Global_Disease/gcmp_global_disease/analysis/organelle_removal/procedure\n"
      ]
     }
    ],

--- a/analysis/organelle_removal/procedure/vsearch.ipynb
+++ b/analysis/organelle_removal/procedure/vsearch.ipynb
@@ -1,44 +1,92 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 3,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "#run vsearch on each tissue compartment using the four references we've\n",
-    "#created, and save the classification taxonomies to /output/"
+    "## Classify Taxonomy with vsearch\n",
+    "\n",
+    "In this notebook we will run vsearch on each tissue compartment using the four references we've\n",
+    "created, and save the classification taxonomies to /output/"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
     "from qiime2 import Artifact\n",
     "from qiime2.plugins.feature_classifier.methods import classify_consensus_vsearch\n",
-    "from qiime2.metadata import Metadata"
+    "from qiime2.metadata import Metadata\n",
+    "from os.path import abspath,exists"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "working_dir = '/home/dylan/Documents/june_reset/'\n",
+    "working_dir = abspath('../')\n",
     "metadata_path = working_dir + '/input/GCMP_EMP_map_r28_no_empty_samples.txt'\n",
-    "seqs_path = working_dir + '/input/GCMP_seqs.qza'"
+    "seqs_path = working_dir + '/output/GCMP_seqs.qza'\n",
+    "taxonomy_reference_dir = working_dir + '/output/taxonomy_references/'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Verify that input files exist at the above paths\n",
+    "\n",
+    "Let's run a quick check to make sure we have everything we need:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verifying that all needed starting data files exist.\n",
+      "Done.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Verifying that all needed starting data files and directories exist.\")\n",
+    "for existing_file in [working_dir,metadata_path,seqs_path,taxonomy_reference_dir]:\n",
+    "    if not exists(existing_file):\n",
+    "        raise IOError(f\"Required file {existing_file} not found. Please ensure it is in that directory.\")\n",
+    "print(\"Done.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Annotate the GCMP sequences\n",
+    "\n",
+    "Next, we'll use vsearch to annotate taxonomy. This will be run once for each of our different taxonomic schemes:\n",
+    "\n",
+    "- Greengenes\n",
+    "- SILVA\n",
+    "- Greengens + MeTaxa2 mitochondrial sequences\n",
+    "- SILVA + MeTaxa2 mitochondrial sequences. \n",
+    "\n",
+    "**NOTE**: This step can take quite a while to run, so we recommend scheduling it for overnight or sometime where you have other things to do (roughly all day on my MacBook Pro using 4 threads)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
-    "tissue_compartments = ['M', 'T', 'S']\n",
     "references = ['greengenes', 'silva', 'greengenes_metaxa2', 'silva_metaxa2']\n",
     "metadata = Metadata.load(metadata_path)\n",
     "seqs = Artifact.load(seqs_path)"
@@ -46,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -56,22 +104,22 @@
       "Running external command line application. This may print messages to stdout and/or stderr.\n",
       "The command being run is below. This command cannot be manually re-run as it will depend on temporary files that no longer exist.\n",
       "\n",
-      "Command: vsearch --usearch_global /tmp/qiime2-archive-frpu61sy/7435f907-a539-4b8f-b28e-242b5c2dc19a/data/dna-sequences.fasta --id 0.8 --query_cov 0.8 --strand both --maxaccepts 10 --maxrejects 0 --output_no_hits --db /tmp/qiime2-archive-zgi0owgj/7c8c997f-3906-4d36-9355-e9d4c5214299/data/dna-sequences.fasta --threads 4 --blast6out /tmp/tmp6jjbrtun\n",
+      "Command: vsearch --usearch_global /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/qiime2-archive-1giqcoxg/444b6d5b-e008-4c59-aa36-7c57adf1cdc7/data/dna-sequences.fasta --id 0.8 --query_cov 0.8 --strand both --maxaccepts 10 --maxrejects 0 --db /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/qiime2-archive-lnfd6_kt/73cb4a20-a0dd-480b-b64a-7fed6571b7cd/data/dna-sequences.fasta --threads 4 --output_no_hits --blast6out /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/tmp_8sa6tvi\n",
       "\n",
       "Running external command line application. This may print messages to stdout and/or stderr.\n",
       "The command being run is below. This command cannot be manually re-run as it will depend on temporary files that no longer exist.\n",
       "\n",
-      "Command: vsearch --usearch_global /tmp/qiime2-archive-frpu61sy/7435f907-a539-4b8f-b28e-242b5c2dc19a/data/dna-sequences.fasta --id 0.8 --query_cov 0.8 --strand both --maxaccepts 10 --maxrejects 0 --output_no_hits --db /tmp/qiime2-archive-jix8y_p_/7282ea51-2531-4e61-8f30-cfea73430726/data/dna-sequences.fasta --threads 4 --blast6out /tmp/tmpu_5t2gvi\n",
+      "Command: vsearch --usearch_global /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/qiime2-archive-1giqcoxg/444b6d5b-e008-4c59-aa36-7c57adf1cdc7/data/dna-sequences.fasta --id 0.8 --query_cov 0.8 --strand both --maxaccepts 10 --maxrejects 0 --db /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/qiime2-archive-gtp3l4_w/17f16b4d-cf24-484c-bf85-58175faefca9/data/dna-sequences.fasta --threads 4 --output_no_hits --blast6out /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/tmp13c8rtqu\n",
       "\n",
       "Running external command line application. This may print messages to stdout and/or stderr.\n",
       "The command being run is below. This command cannot be manually re-run as it will depend on temporary files that no longer exist.\n",
       "\n",
-      "Command: vsearch --usearch_global /tmp/qiime2-archive-frpu61sy/7435f907-a539-4b8f-b28e-242b5c2dc19a/data/dna-sequences.fasta --id 0.8 --query_cov 0.8 --strand both --maxaccepts 10 --maxrejects 0 --output_no_hits --db /tmp/qiime2-archive-crf4f1og/53b43109-0167-4378-84bb-c392f00daa1f/data/dna-sequences.fasta --threads 4 --blast6out /tmp/tmppe6su3kq\n",
+      "Command: vsearch --usearch_global /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/qiime2-archive-1giqcoxg/444b6d5b-e008-4c59-aa36-7c57adf1cdc7/data/dna-sequences.fasta --id 0.8 --query_cov 0.8 --strand both --maxaccepts 10 --maxrejects 0 --db /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/qiime2-archive-4ew2f0wi/e7353932-c0f4-4f46-bb11-71941d13dbe2/data/dna-sequences.fasta --threads 4 --output_no_hits --blast6out /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/tmptht2euap\n",
       "\n",
       "Running external command line application. This may print messages to stdout and/or stderr.\n",
       "The command being run is below. This command cannot be manually re-run as it will depend on temporary files that no longer exist.\n",
       "\n",
-      "Command: vsearch --usearch_global /tmp/qiime2-archive-frpu61sy/7435f907-a539-4b8f-b28e-242b5c2dc19a/data/dna-sequences.fasta --id 0.8 --query_cov 0.8 --strand both --maxaccepts 10 --maxrejects 0 --output_no_hits --db /tmp/qiime2-archive-7xgkkjgw/d8398af0-29d6-41d4-ab37-79a371d12782/data/dna-sequences.fasta --threads 4 --blast6out /tmp/tmp4gyoum6z\n",
+      "Command: vsearch --usearch_global /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/qiime2-archive-1giqcoxg/444b6d5b-e008-4c59-aa36-7c57adf1cdc7/data/dna-sequences.fasta --id 0.8 --query_cov 0.8 --strand both --maxaccepts 10 --maxrejects 0 --db /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/qiime2-archive-rfpqg1ps/c30a0d30-68ce-4142-8e16-4b22c54d54e2/data/dna-sequences.fasta --threads 4 --output_no_hits --blast6out /var/folders/ph/3tshftys2pn638_ypcxd_w58t0gb61/T/tmp4sima0gg\n",
       "\n"
      ]
     }
@@ -79,16 +127,23 @@
    "source": [
     "vsearch_results = {}\n",
     "for reference in references:\n",
-    "    reference_otu_path = working_dir + '/input/' + reference + '_otus.qza'\n",
-    "    reference_taxonomy_path = working_dir + '/input/' + reference + '_taxonomy.qza'\n",
+    "    reference_otu_path = taxonomy_reference_dir + f'{reference}_otus.qza'\n",
+    "    reference_taxonomy_path = taxonomy_reference_dir +  f'{reference}_taxonomy.qza'\n",
     "    reads = Artifact.load(reference_otu_path)\n",
     "    taxonomy = Artifact.load(reference_taxonomy_path)\n",
     "    vsearch_results[reference] = classify_consensus_vsearch(seqs, reads, taxonomy, threads = 4)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Save each of the resulting taxonomy annotations for the GCMP sequences "
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,13 +151,6 @@
     "    classification_taxonomy, = vsearch_results[reference]\n",
     "    classification_taxonomy.save(working_dir + '/output/' + str(reference) + '_reference_taxonomy.qza')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -121,7 +169,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This should work for all the general purpose scripts, but the benchmarking scripts aren't yet finalized.
In particular the final compare annotations script and downstream analyses require a downloader / preprocessor for the Mockrobiota results first